### PR TITLE
Added ability to intercept service method params

### DIFF
--- a/src/server-container.ts
+++ b/src/server-container.ts
@@ -18,6 +18,7 @@ export class InternalServer {
     static cookiesSecret: string;
     static cookiesDecoder: (val: string) => string;
     static fileDest: string;
+    static paramConverter: (paramValue: any, paramType: Function) => any = (p, t) => p;
     static fileFilter: (req: Express.Request, file: Express.Multer.File, callback: (error: Error, acceptFile: boolean) => void) => void;
     static fileLimits: number;
     static serviceFactory: ServiceFactory = {
@@ -340,7 +341,7 @@ export class InternalServer {
                         res.sendStatus(value.statusCode);
                     }
 
-                } else if (value.then) {
+                } else if (value.then && value.catch) {
                     Promise.resolve(value)
                     .then((val: any) => {
                         this.sendValue(val, res, next);
@@ -414,7 +415,7 @@ export class InternalServer {
             case 'Boolean':
                 return paramValue === 'true';
             default:
-                return paramValue;
+                return InternalServer.paramConverter(paramValue, paramType);
         }
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -130,6 +130,14 @@ export class Server {
     }
 
     /**
+     * Sets converter for param values to have an ability to intercept the type that actually will be passed to service
+     * @param fn The converter
+     */
+    static setParamConverter(fn: (paramValue: any, paramType: Function) => any) {
+        InternalServer.paramConverter = fn;
+    }
+
+    /**
      * Creates and endpoint to publish the swagger documentation.
      * @param router Express router
      * @param filePath the path to a swagger file (json or yaml)

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -15,14 +15,16 @@ import {Path, Server, GET, POST, PUT, DELETE,
 Server.useIoC();
 
 export class Person {
-    constructor(id: number, name: string, age: number) {
+    constructor(id: number, name: string, age: number, salary: number = age * 1000) {
         this.id = id;
         this.name = name;
         this.age = age;
+        this.salary = salary;
     }
     id: number;
     name: string;
     age: number;
+    salary: number;
 }
 
 @AutoWired
@@ -117,8 +119,8 @@ class PersonService {
 
     @PUT
     @Path('/:id')
-    setPerson( person: Person): boolean {
-        return true;
+    setPerson( person: Person): number {
+        return person.salary;
     }
 
     @POST
@@ -436,6 +438,12 @@ export function startApi(): Promise<void> {
         app.set('env', 'test');
         Server.buildServices(app, MyIoCService, MyIoCService2, MyIoCService3, MyIoCService4, MyService, MyService2, PersonService, 
 							TestParams, TestDownload, AcceptTest, DateTest, ReferenceService, ErrorService, SuperClassService);
+        Server.setParamConverter((value, type) => {
+            if (type.name === 'Person' && value['salary'] === 424242) {
+                value['salary'] = 434343;
+            }
+            return value;
+        });
         Server.swagger(app, './test/data/swagger.yaml', 'api-docs', 'localhost:5674', ['http']);
         server = app.listen(5674, (err: any) => {
             if (err) {

--- a/test/unit/test.spec.ts
+++ b/test/unit/test.spec.ts
@@ -298,7 +298,7 @@ describe('Server Tests', () => {
                 url: 'http://localhost:5674/asubpath/person/123'
             }, function(error, response, body) {
                 expect(response.statusCode).to.eq(405);
-                const allowed: string = response.headers['allow'];
+                const allowed: string = response.headers['allow'] as string;
                 expect(allowed).to.contain('GET');
                 expect(allowed).to.contain('PUT');
                 done();

--- a/test/unit/test.spec.ts
+++ b/test/unit/test.spec.ts
@@ -40,16 +40,28 @@ describe('Server Tests', () => {
             });
         });
 
-        it('should return true for PUT on path: /asubpath/person/123', (done) => {
+        it('should return salary for PUT on path: /asubpath/person/123', (done) => {
             request.put({
                 body: JSON.stringify(new Person(123, 'Fulano de Tal número 123', 35)),
                 headers: { 'content-type': 'application/json' },
                 url: 'http://localhost:5674/asubpath/person/123'
             }, function(error, response, body) {
-                expect(body).to.eq('true');
+                expect(body).to.eq('35000');
                 done();
             });
         });
+
+        it('should intercept salary 424242 for PUT on path: /asubpath/person/123', (done) => {
+            request.put({
+                body: JSON.stringify(new Person(123, 'Salary Person', 35, 424242)),
+                headers: { 'content-type': 'application/json' },
+                url: 'http://localhost:5674/asubpath/person/123'
+            }, function(error, response, body) {
+                expect(body).to.eq('434343');
+                done();
+            });
+        });
+
 
         it('should return 201 for POST on path: /asubpath/person', (done) => {
             request.post({


### PR DESCRIPTION
My use case for this feature is the following. Instead of taking plain objects in the service methods I want to have classes there (I can explain further why classes are needed if you like). To do that I've implemented a simple plain-js-object to js-class-object mapper and use it in the converting function.