### PR TITLE
Fixed a potential 'run-away promise' bluebird warning

### DIFF
--- a/src/server-container.ts
+++ b/src/server-container.ts
@@ -344,6 +344,7 @@ export class InternalServer {
                     Promise.resolve(value)
                     .then((val: any) => {
                         this.sendValue(val, res, next);
+                        return null;
                     }).catch((err: any) => {
                         next(err);
                     });


### PR DESCRIPTION
Hi,
I'm using bluebird promise implementation in a project instead of the nodejs native one, and bluebird has a feature where it tries to detect run-away promises (a promise created but not returned inside of another promise then-handler): http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it

This PR fixes potential false-positive detection of such promises. Then-handler should return null in cases where it's ok to create and not return a promise inside the then-handler.