### PR TITLE
support default and optional params

### DIFF
--- a/src/server-container.ts
+++ b/src/server-container.ts
@@ -419,9 +419,9 @@ export class InternalServer {
         const serializedType = paramType['name'];
         switch (serializedType) {
             case 'Number':
-                return paramValue ? parseFloat(paramValue) : 0;
+                return paramValue === undefined ? paramValue : parseFloat(paramValue);
             case 'Boolean':
-                return paramValue === 'true';
+                return paramValue === undefined ? paramValue : paramValue === 'true';
             default:
                 return InternalServer.paramConverter(paramValue, paramType);
         }

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -186,6 +186,22 @@ export class TestParams {
         }
     }
 
+    @GET
+    @Path('default-query')
+    testDefaultQuery( @QueryParam('limit') limit: number = 20,
+                      @QueryParam('prefix') prefix: string = 'default',
+                      @QueryParam('expand') expand: boolean = true): string {
+        return `limit:${limit}|prefix:${prefix}|expand:${expand}`;
+    }
+
+    @GET
+    @Path('optional-query')
+    testOptionalQuery( @QueryParam('limit') limit?: number,
+                       @QueryParam('prefix') prefix?: string,
+                       @QueryParam('expand') expand?: boolean): string {
+        return `limit:${limit}|prefix:${prefix}|expand:${expand}`;
+    }
+
     @POST
     @Path('upload')
     testUploadFile( @FileParam('myFile') file: Express.Multer.File, 

--- a/test/unit/test.spec.ts
+++ b/test/unit/test.spec.ts
@@ -228,6 +228,60 @@ describe('Server Tests', () => {
             form.append('myField', 'my_value');
             form.append('myFile', fs.createReadStream(__dirname + '/test.spec.ts'), 'test-rest.spec.ts');
         });
+
+        it('should use sent value for query param that defines a default', (done) => {
+            request({
+                url: 'http://localhost:5674/default-query?limit=5&prefix=test&expand=false'
+            }, function(error, response, body) {
+                expect(body).to.eq('limit:5|prefix:test|expand:false');
+                done();
+            });
+        });
+
+        it('should use provided default value for missing query param', (done) => {
+            request({
+                url: 'http://localhost:5674/default-query'
+            }, function(error, response, body) {
+                expect(body).to.eq('limit:20|prefix:default|expand:true');
+                done();
+            });
+        });
+
+        it('should handle empty string value for default parameter', (done) => {
+            request({
+                url: 'http://localhost:5674/default-query?limit=&prefix=&expand='
+            }, function(error, response, body) {
+                expect(body).to.eq('limit:NaN|prefix:|expand:false');
+                done();
+            });
+        });
+
+        it('should use sent value for optional query param', (done) => {
+            request({
+                url: 'http://localhost:5674/optional-query?limit=5&prefix=test&expand=false'
+            }, function(error, response, body) {
+                expect(body).to.eq('limit:5|prefix:test|expand:false');
+                done();
+            });
+        });
+
+        it('should use undefined as value for missing optional query param', (done) => {
+            request({
+                url: 'http://localhost:5674/optional-query'
+            }, function(error, response, body) {
+                expect(body).to.eq('limit:undefined|prefix:undefined|expand:undefined');
+                done();
+            });
+        });
+
+        it('should handle empty string value for optional parameter', (done) => {
+            request({
+                url: 'http://localhost:5674/optional-query?limit=&prefix=&expand='
+            }, function(error, response, body) {
+                expect(body).to.eq('limit:NaN|prefix:|expand:false');
+                done();
+            });
+        });
     });
     describe('TestDownload', () => {
         it('should return a file', (done) => {


### PR DESCRIPTION
Fixes #35.

This changes the type converter to pass through undefined values, which allows TypeScript's default parameters and optional values to behave as expected. This is a **breaking change** for anyone who relies on undefined values for `number` type parameters to be passed into the service method as `0`.

It also changes empty string to be handled as a valid value. This is a **breaking change** for anyone who expects an empty value to be treated like a missing parameter.