### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ When an object is returned, it is sent as a json serialized string into the resp
 ```typescript
 @GET
 @Path(":id")
-getPerson(@PathParam(":id") id: number): Person {
+getPerson(@PathParam("id") id: number): Person {
   return new Person(id);
 }
 ```


### PR DESCRIPTION
Fix the `PathParam` example in *Service Return* to show the correct syntax for getting a variable from the path.