### PR TITLE
Allow consumer to disable passport session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,12 +298,12 @@ Security is using [passport](https://github.com/jaredhanson/passport) and it can
 `passportAuth` method in `Server`
 
 ```typescript
-Server.passportAuth(strategy, roleKey);
+Server.passportAuth(strategy, roleKey, session);
 ```
 
 - strategy: is part of passport configuration
 - roleKey: by default "*roles*", it is part of user object format
-
+- session: by default false, enables or disables passport session state and will require a user serialization and deserilization function if enabled
 Some examples:
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Server.passportAuth(strategy, roleKey, session);
 - strategy: is part of passport configuration
 - roleKey: by default "*roles*", it is part of user object format
 - session: by default false, enables or disables passport session state and will require a user serialization and deserilization function if enabled
+
 Some examples:
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-rest",
-  "version": "1.7.0",
-  "description": "A Library to create RESTFul APIs with Typescript",
+  "name": "@evari/typescript-rest",
+  "version": "1.7.3",
+  "description": "A Library to create RESTFul APIs with Typescript based on typescript-rest 1.7.0 with added functionality",
   "author": "Thiago da Rosa de Bustamante <thiago@cruxframework.org>",
   "keywords": [
     "API",

--- a/src/server-container.ts
+++ b/src/server-container.ts
@@ -33,6 +33,7 @@ export class InternalServer {
     };
     static passportStrategy: string;
     static roleKey: string;
+    static session: boolean;
 
     router: express.Router;
     upload: multer.Instance;
@@ -41,7 +42,7 @@ export class InternalServer {
         this.router = router;
     }
 
-    static passportAuth(strategy: string, roleKey: string) {
+    static passportAuth(strategy: string, roleKey: string, session: boolean) {
         InternalServer.passportStrategy = strategy;
         InternalServer.roleKey = roleKey;
     }
@@ -147,7 +148,7 @@ export class InternalServer {
         let roles: string[] = [...(serviceMethod.roles || []), ...(serviceClass.roles || [])]
             .filter((role) => !!role);
         if (InternalServer.passportStrategy && roles.length) {
-            args = [...args, passport.authenticate(InternalServer.passportStrategy)];
+            args = [...args, passport.authenticate(InternalServer.passportStrategy, { session: InternalServer.session })];
         }
         roles = roles.filter((role) => role !== '*');
         if (roles.length) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,8 +24,8 @@ export class Server {
     /**
      * Define passportAuth strategy
      */
-    static passportAuth(strategy: string, roleKey: string = 'roles') {
-        InternalServer.passportAuth(strategy, roleKey);
+    static passportAuth(strategy: string, roleKey: string = 'roles', session: boolean = false) {
+        InternalServer.passportAuth(strategy, roleKey, session);
     }
 
     /**


### PR DESCRIPTION
Current master has a hardcoded requirement that for the use of the @Security descriptor that you then also configure passport to have user serialization and deserialization functions to allow passport to manage user sessions.

The option should exist for this to remain entirely stateless, as is desirable for an api with JWT based authentication.