### PR TITLE
allowed consumer to disable passport session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,12 +298,12 @@ Security is using [passport](https://github.com/jaredhanson/passport) and it can
 `passportAuth` method in `Server`
 
 ```typescript
-Server.passportAuth(strategy, roleKey, session);
+Server.passportAuth(strategy, roleKey, options);
 ```
 
 - strategy: is part of passport configuration
 - roleKey: by default "*roles*", it is part of user object format
-- session: by default false, enables or disables passport session state and will require a user serialization and deserilization function if enabled
+- options: by default an empty object of type passport.AuthenticateOptions. Allows configuration of passport configuration such as session, successRedirect or failureRedirect etc.
 
 Some examples:
 

--- a/README.md
+++ b/README.md
@@ -298,11 +298,12 @@ Security is using [passport](https://github.com/jaredhanson/passport) and it can
 `passportAuth` method in `Server`
 
 ```typescript
-Server.passportAuth(strategy, roleKey);
+Server.passportAuth(strategy, roleKey, session);
 ```
 
 - strategy: is part of passport configuration
 - roleKey: by default "*roles*", it is part of user object format
+- session: by default false, enables or disables passport session state and will require a user serialization and deserilization function if enabled
 
 Some examples:
 

--- a/src/server-container.ts
+++ b/src/server-container.ts
@@ -33,7 +33,7 @@ export class InternalServer {
     };
     static passportStrategy: string;
     static roleKey: string;
-    static session: boolean;
+    static options: passport.AuthenticateOptions;
 
     router: express.Router;
     upload: multer.Instance;
@@ -42,10 +42,10 @@ export class InternalServer {
         this.router = router;
     }
 
-    static passportAuth(strategy: string, roleKey: string, session: boolean) {
+    static passportAuth(strategy: string, roleKey: string, options: passport.AuthenticateOptions) {
         InternalServer.passportStrategy = strategy;
         InternalServer.roleKey = roleKey;
-        InternalServer.session = session;
+        InternalServer.options = options;
     }
 
     static registerServiceClass(target: Function): metadata.ServiceClass {
@@ -149,7 +149,7 @@ export class InternalServer {
         let roles: string[] = [...(serviceMethod.roles || []), ...(serviceClass.roles || [])]
             .filter((role) => !!role);
         if (InternalServer.passportStrategy && roles.length) {
-            args = [...args, passport.authenticate(InternalServer.passportStrategy, { session: InternalServer.session })];
+            args = [...args, passport.authenticate(InternalServer.passportStrategy, InternalServer.options)];
         }
         roles = roles.filter((role) => role !== '*');
         if (roles.length) {

--- a/src/server-container.ts
+++ b/src/server-container.ts
@@ -33,6 +33,7 @@ export class InternalServer {
     };
     static passportStrategy: string;
     static roleKey: string;
+    static session: boolean;
 
     router: express.Router;
     upload: multer.Instance;
@@ -41,9 +42,10 @@ export class InternalServer {
         this.router = router;
     }
 
-    static passportAuth(strategy: string, roleKey: string) {
+    static passportAuth(strategy: string, roleKey: string, session: boolean) {
         InternalServer.passportStrategy = strategy;
         InternalServer.roleKey = roleKey;
+        InternalServer.session = session;
     }
 
     static registerServiceClass(target: Function): metadata.ServiceClass {
@@ -147,7 +149,7 @@ export class InternalServer {
         let roles: string[] = [...(serviceMethod.roles || []), ...(serviceClass.roles || [])]
             .filter((role) => !!role);
         if (InternalServer.passportStrategy && roles.length) {
-            args = [...args, passport.authenticate(InternalServer.passportStrategy)];
+            args = [...args, passport.authenticate(InternalServer.passportStrategy, { session: InternalServer.session })];
         }
         roles = roles.filter((role) => role !== '*');
         if (roles.length) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import * as _ from 'lodash';
 import * as fs from 'fs-extra';
 import * as YAML from 'yamljs';
 import * as path from 'path';
+import { AuthenticateOptions } from 'passport';
 
 /**
  * The Http server main class.
@@ -24,8 +25,8 @@ export class Server {
     /**
      * Define passportAuth strategy
      */
-    static passportAuth(strategy: string, roleKey: string = 'roles', session: boolean = false) {
-        InternalServer.passportAuth(strategy, roleKey, session);
+    static passportAuth(strategy: string, roleKey: string = 'roles', options: AuthenticateOptions = {}) {
+        InternalServer.passportAuth(strategy, roleKey, options);
     }
 
     /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,8 +24,8 @@ export class Server {
     /**
      * Define passportAuth strategy
      */
-    static passportAuth(strategy: string, roleKey: string = 'roles') {
-        InternalServer.passportAuth(strategy, roleKey);
+    static passportAuth(strategy: string, roleKey: string = 'roles', session: boolean = false) {
+        InternalServer.passportAuth(strategy, roleKey, session);
     }
 
     /**


### PR DESCRIPTION
Current master has a hardcoded requirement that for the use of the @Security descriptor that you then also configure passport to have user serialization and deserialization functions to allow passport to manage user sessions.

The option should exist for this to remain entirely stateless, as is desirable for an api with JWT based authentication.