### PR TITLE
Inject custom Express request properties using @ContextRequestProperty decorator

### DIFF
--- a/src/decorators/parameters.ts
+++ b/src/decorators/parameters.ts
@@ -57,6 +57,40 @@ export function ContextRequest(...args: Array<any>) {
 /**
  * A decorator to be used on class properties or on service method arguments
  * to inform that the decorated property or argument should be bound to the
+ * the given property name in the current request. This could be used, for
+ * example, to extract values inserted by prior middlewares into the request
+ * object.
+ *
+ * For example:
+ *
+ * ```
+ * const authMiddleware = async (req, res, next) => {
+ *   const userId: string = await authenticateRequestAndReturnCurrentUserId(...);
+ *   req.userId = userId;
+ *   next();
+ * }
+ * 
+ * ...
+ * 
+ * @ Path('people')
+ * class PeopleService {
+ *   @ GET
+ *   getCurrentUser(@ ContextRequestProperty('userId') userId: string) {
+ * }
+ * ```
+ *
+ * The `authMiddleware` function will insert the `userId` property into
+ * the request object. Then, that value will be passed along into the
+ * `userId` parameter when `getCurrentUser` is called.
+ */
+export function ContextRequestProperty(name: string) {
+    return new ParameterDecorator('ContextRequestProperty').withType(ParamType.context_request_property).withName(name)
+        .decorateNamedParameterOrProperty();
+}
+
+/**
+ * A decorator to be used on class properties or on service method arguments
+ * to inform that the decorated property or argument should be bound to the
  * the current response object.
  *
  * For example:

--- a/src/decorators/parameters.ts
+++ b/src/decorators/parameters.ts
@@ -55,11 +55,9 @@ export function ContextRequest(...args: Array<any>) {
 }
 
 /**
- * A decorator to be used on class properties or on service method arguments
- * to inform that the decorated property or argument should be bound to the
- * the given property name in the current request. This could be used, for
- * example, to extract values inserted by prior middlewares into the request
- * object.
+ * Creates a mapping between properties on the request object and a method
+ * argument. This could be used, for example, to extract values inserted by
+ * prior middlewares into the request.
  *
  * For example:
  *

--- a/src/server/model/metadata.ts
+++ b/src/server/model/metadata.ts
@@ -115,6 +115,7 @@ export enum ParamType {
     files = 'files',
     context = 'context',
     context_request = 'context_request',
+    context_request_property = 'context_request_property',
     context_response = 'context_response',
     context_next = 'context_next',
     context_accept = 'context_accept',

--- a/src/server/parameter-processor.ts
+++ b/src/server/parameter-processor.ts
@@ -42,6 +42,7 @@ export class ParameterProcessor {
         parameterMapper.set(ParamType.header, (context, property) => this.convertType(context.request.header(property.name), property.propertyType));
         parameterMapper.set(ParamType.cookie, (context, property) => this.convertType(context.request.cookies[property.name], property.propertyType));
         parameterMapper.set(ParamType.body, (context, property) => this.convertType(context.request.body, property.propertyType));
+        parameterMapper.set(ParamType.context_request_property, (context, property) => this.convertType((context.request as any)[property.name], property.propertyType));
         parameterMapper.set(ParamType.file, (context, property) => {
             this.debugger.runtime('Processing file parameter');
             // @ts-ignore

--- a/test/integration/datatypes.spec.ts
+++ b/test/integration/datatypes.spec.ts
@@ -9,7 +9,7 @@ import * as request from 'request';
 import { Container } from 'typescript-ioc';
 import {
     BodyOptions, BodyType, Context, ContextNext,
-    ContextRequest, ContextResponse, CookieParam, FileParam, FormParam,
+    ContextRequest, ContextRequestProperty, ContextResponse, CookieParam, FileParam, FormParam,
     GET, HeaderParam, Param, ParserType, Path, PathParam, POST, PUT, QueryParam, Return, Server, ServiceContext
 } from '../../src/typescript-rest';
 const expect = chai.expect;

--- a/test/integration/datatypes.spec.ts
+++ b/test/integration/datatypes.spec.ts
@@ -245,11 +245,11 @@ export class TestContextRequestPropertyService {
     @Path('nonexistent')
     @PreProcessor(testContextRequestPropertyMiddleware)
     public testNonexistentInjection(@ContextRequestProperty('otherName') otherName: string) {
-        if (otherName) {
-            return 'NOT OK';
+        if (!otherName) {
+            return 'OK';
         }
         else {
-            return 'OK';
+            return 'NOT OK';
         }
     }
 }

--- a/test/integration/datatypes.spec.ts
+++ b/test/integration/datatypes.spec.ts
@@ -10,7 +10,7 @@ import { Container } from 'typescript-ioc';
 import {
     BodyOptions, BodyType, Context, ContextNext,
     ContextRequest, ContextRequestProperty, ContextResponse, CookieParam, FileParam, FormParam,
-    GET, HeaderParam, Param, ParserType, Path, PathParam, POST, PUT, QueryParam, Return, Server, ServiceContext
+    GET, HeaderParam, Param, ParserType, Path, PathParam, POST, PreProcessor, PUT, QueryParam, Return, Server, ServiceContext
 } from '../../src/typescript-rest';
 const expect = chai.expect;
 
@@ -220,6 +220,37 @@ export class TestReturnService {
         const result = new Return.NewResource<Container>(req.url + '/123');
         result.body = new Container();
         return result;
+    }
+}
+
+export function testContextRequestPropertyMiddleware(req: any) {
+    req.userId = '123';
+}
+
+@Path("testcontextrequestproperty")
+export class TestContextRequestPropertyService {
+    @GET
+    @Path('existent')
+    @PreProcessor(testContextRequestPropertyMiddleware)
+    public testSuccessfulInjection(@ContextRequestProperty('userId') userId: string) {
+        if (userId === '123') {
+            return 'OK';
+        }
+        else {
+            return 'NOT OK';
+        }
+    }
+
+    @GET
+    @Path('nonexistent')
+    @PreProcessor(testContextRequestPropertyMiddleware)
+    public testNonexistentInjection(@ContextRequestProperty('otherName') otherName: string) {
+        if (otherName) {
+            return 'NOT OK';
+        }
+        else {
+            return 'OK';
+        }
     }
 }
 
@@ -525,6 +556,7 @@ describe('Data Types Tests', () => {
             });
         });
     });
+    
 
     describe('Param Converters', () => {
         it('should intercept parameters', (done) => {
@@ -548,7 +580,25 @@ describe('Data Types Tests', () => {
         });
     });
 
+    describe('ContextRequestProperty injection', () => {
+        it('should have injected an existent request property', (done) => {
+            request.get({
+                url: 'http://localhost:5674/testcontextrequestproperty/existent'
+            }, (error, response, body) => {
+                expect(body).to.eq('OK');
+                done();
+            });
+        });
 
+        it('should not have injected a non-existent request property', (done) => {
+            request.get({
+                url: 'http://localhost:5674/testcontextrequestproperty/nonexistent'
+            }, (error, response, body) => {
+                expect(body).to.eq('OK');
+                done();
+            });
+        });
+    });
 
 });
 
@@ -558,7 +608,7 @@ export function startApi(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
         const app: express.Application = express();
         app.set('env', 'test');
-        Server.buildServices(app, TestParamsService, TestReturnService);
+        Server.buildServices(app, TestParamsService, TestReturnService, TestContextRequestPropertyService);
         app.use('/testreturn', (req, res, next) => {
             if (!res.headersSent) {
                 res.send('handled by middleware');

--- a/test/unit/decorators.spec.ts
+++ b/test/unit/decorators.spec.ts
@@ -361,7 +361,8 @@ describe('Decorators', () => {
         { name: 'HeaderParam', paramType: ParamType.header },
         { name: 'CookieParam', paramType: ParamType.cookie },
         { name: 'FormParam', paramType: ParamType.form },
-        { name: 'Param', paramType: ParamType.param }
+        { name: 'Param', paramType: ParamType.param },
+        // { name: 'ContextRequestProperty', paramType: ParamType.context_request_property }
     ].forEach(test => {
         describe(`${test.name} Decorator`, () => {
             it(`should bind a @${test.name} to one service property`, async () => {


### PR DESCRIPTION
Allows the following behavior:

 ```
 const authMiddleware = async (req, res, next) => {
   const userId: string = await authenticateRequestAndReturnCurrentUserId(...);
   req.userId = userId;
   next();
}
 
 ...
 
 @ Path('people')
 class PeopleService {
   @ GET
   getCurrentUser(@ ContextRequestProperty('userId') userId: string) {
 }
 ```