### PR TITLE
fix(service): Fix service invoker null return

### DIFF
--- a/src/server/service-invoker.ts
+++ b/src/server/service-invoker.ts
@@ -188,11 +188,10 @@ export class ServiceInvoker {
                         context.response.sendStatus(204);
                     }
                     break;
-                case null:
-                    context.response.send(value);
-                    break;
                 default:
-                    await this.sendComplexValue(context, value);
+                    value === null 
+                        ? context.response.send(value) 
+                        : await this.sendComplexValue(context, value);
             }
         } else {
             this.debugger('Do not send any response value');


### PR DESCRIPTION
This solves the `null` return error.

The PR https://github.com/thiagobustamante/typescript-rest/pull/95 did not solve the issue as the `typeof null` is `object` and the `switch...case` was checking for `null` as the type which is not valid.

Closes https://github.com/thiagobustamante/typescript-rest/issues/93