### PR TITLE
Wait for the reponse from async methods before executing postProcessors

### DIFF
--- a/src/server/service-invoker.ts
+++ b/src/server/service-invoker.ts
@@ -69,7 +69,7 @@ export class ServiceInvoker {
         if (this.debugger.enabled) {
             this.debugger('Invoking service method <%s> with params: %j', this.serviceMethod.name, args);
         }
-        const result = toCall.apply(serviceObject, args);
+        const result = await toCall.apply(serviceObject, args);
         if (this.postProcessors.length) {
             await this.runPostProcessors(context);
         }


### PR DESCRIPTION
Postprocessors do not wait for the answer from async service methods.
I quickly tested this fix and it seems to work