### PR TITLE
Authenticator: Add res param to getRoles() function

### DIFF
--- a/src/server/model/server-types.ts
+++ b/src/server/model/server-types.ts
@@ -103,7 +103,7 @@ export interface ServiceAuthenticator {
     /**
      * Get the user list of roles.
      */
-    getRoles: (req: express.Request) => Array<string>;
+    getRoles: (req: express.Request, res: express.Response) => Array<string>;
     /**
      * Initialize the authenticator
      */

--- a/src/server/server-container.ts
+++ b/src/server/server-container.ts
@@ -352,7 +352,7 @@ export class ServerContainer {
 
     private buildAuthMiddleware(authenticator: ServiceAuthenticator, roles: Array<string>): express.RequestHandler {
         return (req: Request, res: Response, next: NextFunction) => {
-            const requestRoles = authenticator.getRoles(req);
+            const requestRoles = authenticator.getRoles(req, res);
             if (this.debugger.runtime.enabled) {
                 this.debugger.runtime('Validating authentication roles: <%j>.', requestRoles);
             }


### PR DESCRIPTION
This allows access to the `res.locals` variable which commonly stores data between middleware: 

https://expressjs.com/en/api.html#res.locals

>**res.locals** An object that contains response local variables scoped to the request, and therefore available only to the view(s) rendered during that request / response cycle (if any). Otherwise, this property is identical to app.locals.
> 
> This property is useful for exposing request-level information such as the request path name, authenticated user, user settings, and so on.