### PR TITLE
added query param handling of arrays so that single values are receiv…

### DIFF
--- a/src/server/parameter-processor.ts
+++ b/src/server/parameter-processor.ts
@@ -80,6 +80,8 @@ export class ParameterProcessor {
                 return paramValue === undefined ? paramValue : parseFloat(paramValue as string);
             case 'Boolean':
                 return paramValue === undefined ? paramValue : paramValue === 'true' || paramValue === true;
+            case 'Array':
+                return paramValue === undefined ? paramValue : [].concat(paramValue);
             default:
                 let converter = ServerContainer.get().paramConverters.get(paramType);
                 if (!converter) {

--- a/test/integration/datatypes.spec.ts
+++ b/test/integration/datatypes.spec.ts
@@ -145,6 +145,12 @@ export class TestParamsService {
         return `limit:${limit}|prefix:${prefix}|expand:${expand}`;
     }
 
+    @GET
+    @Path('array-query')
+    public testArrayQuery(@QueryParam('prefix') prefixes: Array<string>): string {
+        return prefixes === undefined ? 'undefined' : JSON.stringify(prefixes);
+    }
+
     @POST
     @Path('upload')
     public testUploadFile(@FileParam('myFile') file: Express.Multer.File,
@@ -242,7 +248,7 @@ describe('Data Types Tests', () => {
             });
         });
 
-        it('should be able to receive parametes as Objects', (done) => {
+        it('should be able to receive parameters as Objects', (done) => {
             const person = new Person(123, 'Person 123', 35);
             request.put({
                 body: JSON.stringify(person),
@@ -420,6 +426,33 @@ describe('Data Types Tests', () => {
                 url: 'http://localhost:5674/testparams/optional-query?limit=&prefix=&expand='
             }, (error, response, body) => {
                 expect(body).to.eq('limit:NaN|prefix:|expand:false');
+                done();
+            });
+        });
+
+        it('should use undefined as value for missing array query param', (done) => {
+            request({
+                url: 'http://localhost:5674/testparams/array-query'
+            }, (error, response, body) => {
+                expect(body).to.eq('undefined');
+                done();
+            });
+        });
+
+        it('should handle an array of values for duplicate query param names', (done) => {
+            request({
+                url: 'http://localhost:5674/testparams/array-query?&prefix=abc&prefix=123'
+            }, (error, response, body) => {
+                expect(body).to.eq('["abc","123"]');
+                done();
+            });
+        });
+
+        it('should allow an array of one when expected query param type is an array', (done) => {
+            request({
+                url: 'http://localhost:5674/testparams/array-query?&prefix=abc'
+            }, (error, response, body) => {
+                expect(body).to.eq('["abc"]');
                 done();
             });
         });


### PR DESCRIPTION
Update for issue #99 
https://github.com/thiagobustamante/typescript-rest/issues/99

Greetings!  I stumbled upon your repository last night while looking for interesting projects for #hacktoberfest.  I will admit, I love this approach to building RESTful services.  It mirrors almost exactly my experience with working with jax-rs in Java REST services.  Its a very clear and concise approach to working with REST.  I plan on using this in some upcoming personal projects.

Updated `./src/server/parameter-processor.ts` for better handling of expected array types on query parameters.
- Added a concat step when the expected type is an array.  This will convert single objects into an array of one or preserve existing arrays as-is
- Added tests for array query params types
- Fixed a typo in the description of a test that I just happened to notice
- Code coverage slightly improved by additions