### PR TITLE
Allow Multiple Security Decorators

### DIFF
--- a/src/decorators/services.ts
+++ b/src/decorators/services.ts
@@ -76,9 +76,8 @@ export function Path(path: string) {
  */
 export function Security(roles?: string | Array<string>, name?: string) {
     roles = _.castArray(roles || '*');
-    return new ServiceDecorator('Security')
-        .withProperty('roles', roles)
-        .withProperty('authenticator', name || 'default')
+    return new SecurityServiceDecorator('Security')
+        .withObjectProperty('authenticator', name || 'default', roles)
         .createDecorator();
 }
 
@@ -335,6 +334,24 @@ class ServiceDecorator {
         this.properties.forEach(property => {
             property.process(serviceMethod);
         });
+    }
+}
+
+class SecurityServiceDecorator extends ServiceDecorator {
+    public withObjectProperty(property: string, subtext: string, value: any, required: boolean = false) {
+        this.properties.push({
+            checkRequired: () => required && !value,
+            process: (target: any) => {
+                if (!target[property]) {
+                    target[property] = {};
+                }
+                target[property][subtext] = value;
+            },
+            property: property,
+            required: required,
+            value: value
+        });
+        return this;
     }
 }
 

--- a/src/server/model/metadata.ts
+++ b/src/server/model/metadata.ts
@@ -16,8 +16,7 @@ export class ServiceClass {
 
     public targetClass: any;
     public path: string;
-    public roles: Array<string>;
-    public authenticator: string;
+    public authenticator: Record<string, Array<string>>;
     public preProcessors: Array<ServiceProcessor>;
     public postProcessors: Array<ServiceProcessor>;
     public methods: Map<string, ServiceMethod>;
@@ -51,8 +50,7 @@ export class ServiceMethod {
 
     public name: string;
     public path: string;
-    public roles: Array<string>;
-    public authenticator: string;
+    public authenticator: Record<string, Array<string>>;
     public resolvedPath: string;
     public httpMethod: HttpMethod;
     public parameters: Array<MethodParam> = new Array<MethodParam>();

--- a/src/server/server-container.ts
+++ b/src/server/server-container.ts
@@ -326,17 +326,20 @@ export class ServerContainer {
 
     private buildSecurityMiddlewares(serviceClass: ServiceClass, serviceMethod: ServiceMethod) {
         const result: Array<express.RequestHandler> = new Array<express.RequestHandler>();
-        let roles: Array<string> = _.compact(_.union(serviceMethod.roles, serviceClass.roles));
-        const authenticatorName: string = serviceMethod.authenticator || serviceClass.authenticator;
-        if (this.authenticator && authenticatorName && roles.length) {
-            this.debugger.build('Registering an authenticator middleware <%s> for method <%s>.', authenticatorName, serviceMethod.name);
-            const authenticator = this.getAuthenticator(authenticatorName);
-            result.push(authenticator.getMiddleware());
-            roles = roles.filter((role) => role !== '*');
-            if (roles.length) {
-                this.debugger.build('Registering a role validator middleware <%s> for method <%s>.', authenticatorName, serviceMethod.name);
-                this.debugger.build('Roles: <%j>.', roles);
-                result.push(this.buildAuthMiddleware(authenticator, roles));
+        const authenticatorMap: Record<string, Array<string>> | undefined = serviceMethod.authenticator || serviceClass.authenticator;
+        if (this.authenticator && authenticatorMap) {
+            const authenticatorNames: Array<string> = Object.keys(authenticatorMap);
+            for (const authenticatorName of authenticatorNames) {
+                let roles: Array<string> = authenticatorMap[authenticatorName];
+                this.debugger.build('Registering an authenticator middleware <%s> for method <%s>.', authenticatorName, serviceMethod.name);
+                const authenticator = this.getAuthenticator(authenticatorName);
+                result.push(authenticator.getMiddleware());
+                roles = roles.filter((role) => role !== '*');
+                if (roles.length) {
+                    this.debugger.build('Registering a role validator middleware <%s> for method <%s>.', authenticatorName, serviceMethod.name);
+                    this.debugger.build('Roles: <%j>.', roles);
+                    result.push(this.buildAuthMiddleware(authenticator, roles));
+                }
             }
         }
 

--- a/test/unit/decorators.spec.ts
+++ b/test/unit/decorators.spec.ts
@@ -105,8 +105,8 @@ describe('Decorators', () => {
             serviceDecorators.Security(role)(TestService);
 
             expect(serverStub.registerServiceClass).to.have.been.calledOnceWithExactly(TestService);
-            expect(serviceClass.roles).to.have.length(1);
-            expect(serviceClass.roles).to.includes(role);
+            expect(serviceClass.authenticator.default).to.have.length(1);
+            expect(serviceClass.authenticator.default).to.includes(role);
         });
 
         it('should add a security role to methods of a class', async () => {
@@ -115,8 +115,8 @@ describe('Decorators', () => {
                 Object.getOwnPropertyDescriptor(TestService.prototype, 'test'));
 
             expect(serverStub.registerServiceMethod).to.have.been.calledOnce;
-            expect(serviceMethod.roles).to.have.length(1);
-            expect(serviceMethod.roles).to.includes(role);
+            expect(serviceMethod.authenticator.default).to.have.length(1);
+            expect(serviceMethod.authenticator.default).to.includes(role);
         });
 
         it('should add a security set of roles to methods of a class', async () => {
@@ -125,8 +125,8 @@ describe('Decorators', () => {
                 Object.getOwnPropertyDescriptor(TestService.prototype, 'test'));
 
             expect(serverStub.registerServiceMethod).to.have.been.calledOnce;
-            expect(serviceMethod.roles).to.have.length(2);
-            expect(serviceMethod.roles).to.include.members(roles);
+            expect(serviceMethod.authenticator.default).to.have.length(2);
+            expect(serviceMethod.authenticator.default).to.include.members(roles);
         });
 
         it('should add a security validation to accept any role when empty is received', async () => {
@@ -135,8 +135,8 @@ describe('Decorators', () => {
                 Object.getOwnPropertyDescriptor(TestService.prototype, 'test'));
 
             expect(serverStub.registerServiceMethod).to.have.been.calledOnce;
-            expect(serviceMethod.roles).to.have.length(1);
-            expect(serviceMethod.roles).to.include.members(['*']);
+            expect(serviceMethod.authenticator.default).to.have.length(1);
+            expect(serviceMethod.authenticator.default).to.include.members(['*']);
         });
 
         it('should add a security validation to accept any role when undefined is received', async () => {
@@ -145,8 +145,8 @@ describe('Decorators', () => {
                 Object.getOwnPropertyDescriptor(TestService.prototype, 'test'));
 
             expect(serverStub.registerServiceMethod).to.have.been.calledOnce;
-            expect(serviceMethod.roles).to.have.length(1);
-            expect(serviceMethod.roles).to.include.members(['*']);
+            expect(serviceMethod.authenticator.default).to.have.length(1);
+            expect(serviceMethod.authenticator.default).to.include.members(['*']);
         });
 
         it('should set the default authenticator if no name is provided', async () => {
@@ -155,9 +155,9 @@ describe('Decorators', () => {
                 Object.getOwnPropertyDescriptor(TestService.prototype, 'test'));
 
             expect(serverStub.registerServiceMethod).to.have.been.calledOnce;
-            expect(serviceMethod.roles).to.have.length(1);
-            expect(serviceMethod.roles).to.includes(role);
-            expect(serviceMethod.authenticator).to.be.equals('default');
+            expect(serviceMethod.authenticator.default).to.have.length(1);
+            expect(serviceMethod.authenticator.default).to.includes(role);
+            expect(Object.keys(serviceMethod.authenticator)).to.deep.equals(['default']);
         });
 
         it('should set the authenticator name, when name is provided', async () => {
@@ -167,9 +167,28 @@ describe('Decorators', () => {
                 Object.getOwnPropertyDescriptor(TestService.prototype, 'test'));
 
             expect(serverStub.registerServiceMethod).to.have.been.calledOnce;
-            expect(serviceMethod.roles).to.have.length(1);
-            expect(serviceMethod.roles).to.includes(role);
-            expect(serviceMethod.authenticator).to.be.equals(name);
+            expect(serviceMethod.authenticator[name]).to.have.length(1);
+            expect(serviceMethod.authenticator[name]).to.includes(role);
+            expect(Object.keys(serviceMethod.authenticator)).to.deep.equals([name]);
+        });
+
+        it('should set multiple authenticator names', async () => {
+            const role1: string = 'test-role-1';
+            const role2: string = 'test-role-2';
+            const name1: string = 'authenticator-name-1';
+            const name2: string = 'authenticator-name-2';
+            serviceDecorators.Security(role1, name1)(TestService.prototype, 'test',
+                Object.getOwnPropertyDescriptor(TestService.prototype, 'test'));
+            serviceDecorators.Security(role2, name2)(TestService.prototype, 'test',
+                Object.getOwnPropertyDescriptor(TestService.prototype, 'test'));
+
+            expect(serverStub.registerServiceMethod).to.have.been.calledTwice;
+            expect(serviceMethod.authenticator[name1]).to.have.length(1);
+            expect(serviceMethod.authenticator[name2]).to.have.length(1);
+            expect(serviceMethod.authenticator[name1]).to.includes(role1);
+            expect(serviceMethod.authenticator[name2]).to.includes(role2);
+            expect(Object.keys(serviceMethod.authenticator)).to.have.length(2);
+            expect(Object.keys(serviceMethod.authenticator)).to.deep.equals([name1, name2]);
         });
 
         it('should throw an error if misused', async () => {


### PR DESCRIPTION
Fixes #146 

Instead of hard-coding the authenticator name and roles in single properties, it creates an object to store any that are assigned. This enables multiple security decorators to be used on top of each other.

e.g.
```ts
@Security(['admin'], 'roles')
@Security([1, 2, 3], 'org')
```
Creates:
```js
{
    roles: ['admin'],
    org: [1,2,3],
}
```
Which will then loop through each property and apply the associated authenticator middleware.