### PR TITLE
feat: provide controller result to PostProcessor functions

### DIFF
--- a/src/decorators/services.ts
+++ b/src/decorators/services.ts
@@ -3,7 +3,7 @@
 import * as _ from 'lodash';
 import 'reflect-metadata';
 import { ServiceClass, ServiceMethod } from '../server/model/metadata';
-import { ParserType, ServiceProcessor } from '../server/model/server-types';
+import { ParserType, ServicePostProcessor, ServicePreProcessor } from '../server/model/server-types';
 import { ServerContainer } from '../server/server-container';
 
 /**
@@ -108,7 +108,7 @@ export function Security(roles?: string | Array<string>, name?: string) {
  * }
  * ```
  */
-export function PreProcessor(preprocessor: ServiceProcessor) {
+export function PreProcessor(preprocessor: ServicePreProcessor) {
     return new ProcessorServiceDecorator('PreProcessor')
         .withArrayProperty('preProcessors', preprocessor, true)
         .createDecorator();
@@ -140,7 +140,7 @@ export function PreProcessor(preprocessor: ServiceProcessor) {
  * }
  * ```
  */
-export function PostProcessor(postprocessor: ServiceProcessor) {
+export function PostProcessor(postprocessor: ServicePostProcessor) {
     return new ProcessorServiceDecorator('PostProcessor')
         .withArrayProperty('postProcessors', postprocessor, true)
         .createDecorator();

--- a/src/server/model/metadata.ts
+++ b/src/server/model/metadata.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { HttpMethod, ParserType, ServiceProcessor } from './server-types';
+import { HttpMethod, ParserType, ServicePreProcessor, ServicePostProcessor } from './server-types';
 
 export interface ServiceProperty {
     type: ParamType;
@@ -18,8 +18,8 @@ export class ServiceClass {
     public path: string;
     public roles: Array<string>;
     public authenticator: string;
-    public preProcessors: Array<ServiceProcessor>;
-    public postProcessors: Array<ServiceProcessor>;
+    public preProcessors: Array<ServicePreProcessor>;
+    public postProcessors: Array<ServicePostProcessor>;
     public methods: Map<string, ServiceMethod>;
     public bodyParserOptions: any;
     public bodyParserType: ParserType;
@@ -67,8 +67,8 @@ export class ServiceMethod {
     public accepts: Array<string>;
     public resolvedLanguages: Array<string>;
     public resolvedAccepts: Array<string>;
-    public preProcessors: Array<ServiceProcessor>;
-    public postProcessors: Array<ServiceProcessor>;
+    public preProcessors: Array<ServicePreProcessor>;
+    public postProcessors: Array<ServicePostProcessor>;
     public ignoreNextMiddlewares: boolean = false;
 }
 

--- a/src/server/model/server-types.ts
+++ b/src/server/model/server-types.ts
@@ -114,7 +114,8 @@ export interface ServiceAuthenticator {
     getMiddleware(): express.RequestHandler;
 }
 
-export type ServiceProcessor = (req: express.Request, res?: express.Response) => void;
+export type ServicePreProcessor = (req: express.Request, res?: express.Response) => void;
+export type ServicePostProcessor = (req: express.Request, res?: express.Response, result?: any) => void;
 export type ParameterConverter = (paramValue: any) => any;
 
 /**


### PR DESCRIPTION
This PR introduces the option that all `@PostProcessor` decorators can access the result of the controller method. 

This is useful as one could validate the returned result against a swagger schema inside a processor function.