### PR TITLE
Add reports/ and .github/ to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
 !dist/
+reports/
+.github/
 .travis.yml
 *.log
 npm-debug.log*


### PR DESCRIPTION
This PR allows to reduce build size and remove redundant files from the package.